### PR TITLE
chore: promote jkx-golang2 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jkx-golang2/jkx-golang2-jkx-golang2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang2/jkx-golang2-jkx-golang2-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jkx-golang2-jkx-golang2
   labels:
     draft: draft-app
-    chart: "jkx-golang2-0.0.1"
+    chart: "jkx-golang2-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jkx-golang2'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jkx-golang2-jkx-golang2
       containers:
         - name: jkx-golang2
-          image: "10.105.32.3/borderx/jkx-golang2:0.0.1"
+          image: "10.105.32.3/borderx/jkx-golang2:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jkx-golang2/jkx-golang2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang2/jkx-golang2-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jkx-golang2
   labels:
-    chart: "jkx-golang2-0.0.1"
+    chart: "jkx-golang2-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jkx-golang2'

--- a/config-root/namespaces/server1/jenkins/templates/tests/jenkins-ui-test-b8gde-pod.yaml
+++ b/config-root/namespaces/server1/jenkins/templates/tests/jenkins-ui-test-b8gde-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-ibgge"
+  name: "jenkins-ui-test-b8gde"
   namespace: server1
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jkx-golang2 </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -187,13 +187,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-01-29T15:54:57Z"
+    firstDeployed: "2022-01-29T16:58:46Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-01-29T15:54:57Z"
+    lastDeployed: "2022-01-29T16:58:46Z"
     name: jkx-golang2
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/jkx-golang2
-    version: 0.0.1
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jkx-golang2
-  version: 0.0.1
+  version: 0.0.2
   name: jkx-golang2
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jkx-golang2 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
