### PR TITLE
chore: promote jkx-golang3 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jkx-golang3/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jkx-golang3'
+  name: jkx-golang3
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jkx-golang3
+                port:
+                  number: 80
+      host: jkx-golang3-jx-staging.192.168.64.3.nip.io

--- a/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-jkx-golang3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-jkx-golang3-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jkx-golang3/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jkx-golang3-jkx-golang3
+  labels:
+    draft: draft-app
+    chart: "jkx-golang3-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jkx-golang3'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jkx-golang3-jkx-golang3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jkx-golang3-jkx-golang3
+    spec:
+      serviceAccountName: jkx-golang3-jkx-golang3
+      containers:
+        - name: jkx-golang3
+          image: "10.105.32.3/borderx/jkx-golang3:0.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-jkx-golang3-sa.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-jkx-golang3-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jkx-golang3/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jkx-golang3-jkx-golang3
+  annotations:
+    meta.helm.sh/release-name: 'jkx-golang3'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-svc.yaml
+++ b/config-root/namespaces/jx-staging/jkx-golang3/jkx-golang3-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jkx-golang3/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jkx-golang3
+  labels:
+    chart: "jkx-golang3-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jkx-golang3'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jkx-golang3-jkx-golang3

--- a/config-root/namespaces/server1/jenkins/templates/tests/jenkins-ui-test-ne9dw-pod.yaml
+++ b/config-root/namespaces/server1/jenkins/templates/tests/jenkins-ui-test-ne9dw-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-0kvys"
+  name: "jenkins-ui-test-ne9dw"
   namespace: server1
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,12 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jkx-golang3 </a></td>
+	      <td>0.0.2</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -197,3 +197,14 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/jkx-golang2
     version: 0.0.2
+  - apiVersion: v1
+    appVersion: 0.0.2
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-01-30T03:38:32Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-01-30T03:38:32Z"
+    name: jkx-golang3
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    resourcePath: config-root/namespaces/jx-staging/jkx-golang3
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/jkx-golang3
   version: 0.0.2
   name: jkx-golang3
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: jkx-golang2
   values:
   - jx-values.yaml
+- chart: dev/jkx-golang3
+  version: 0.0.2
+  name: jkx-golang3
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jkx-golang3 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
